### PR TITLE
intellij xml for ver 14+, static imports at top

### DIFF
--- a/intellij-java-google-style.xml
+++ b/intellij-java-google-style.xml
@@ -1,21 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <code_scheme name="GoogleStyle">
-  <option name="JAVA_INDENT_OPTIONS">
-    <value>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="8" />
-      <option name="USE_TAB_CHARACTER" value="false" />
-      <option name="SMART_TABS" value="false" />
-      <option name="LABEL_INDENT_SIZE" value="0" />
-      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-      <option name="USE_RELATIVE_INDENTS" value="false" />
-    </value>
-  </option>
   <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
   <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
   <option name="IMPORT_LAYOUT_TABLE">
     <value>
+      <package name="" withSubpackages="true" static="true" />
+      <emptyLine />
       <package name="com.google" withSubpackages="true" static="false" />
       <emptyLine />
       <package name="android" withSubpackages="true" static="false" />
@@ -247,8 +236,6 @@
       <package name="javax" withSubpackages="true" static="false" />
       <emptyLine />
       <package name="" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="" withSubpackages="true" static="true" />
     </value>
   </option>
   <option name="RIGHT_MARGIN" value="100" />
@@ -256,127 +243,34 @@
   <option name="JD_KEEP_EMPTY_PARAMETER" value="false" />
   <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
   <option name="JD_KEEP_EMPTY_RETURN" value="false" />
-  <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
-  <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-  <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
-  <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
-  <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
-  <option name="ALIGN_MULTILINE_ASSIGNMENT" value="true" />
-  <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true" />
-  <option name="ALIGN_MULTILINE_THROWS_LIST" value="true" />
-  <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
-  <option name="ALIGN_MULTILINE_PARENTHESIZED_EXPRESSION" value="true" />
-  <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
-  <option name="CALL_PARAMETERS_WRAP" value="1" />
-  <option name="METHOD_PARAMETERS_WRAP" value="1" />
-  <option name="EXTENDS_LIST_WRAP" value="1" />
-  <option name="THROWS_LIST_WRAP" value="1" />
-  <option name="EXTENDS_KEYWORD_WRAP" value="1" />
-  <option name="THROWS_KEYWORD_WRAP" value="1" />
-  <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
-  <option name="BINARY_OPERATION_WRAP" value="1" />
-  <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
-  <option name="TERNARY_OPERATION_WRAP" value="1" />
-  <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
-  <option name="FOR_STATEMENT_WRAP" value="1" />
-  <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-  <option name="ASSIGNMENT_WRAP" value="5" />
-  <option name="WRAP_COMMENTS" value="true" />
-  <option name="IF_BRACE_FORCE" value="3" />
-  <option name="DOWHILE_BRACE_FORCE" value="3" />
-  <option name="WHILE_BRACE_FORCE" value="3" />
-  <option name="FOR_BRACE_FORCE" value="3" />
-  <ADDITIONAL_INDENT_OPTIONS fileType="css">
-    <option name="INDENT_SIZE" value="4" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="haml">
-    <option name="INDENT_SIZE" value="2" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="java">
-    <option name="INDENT_SIZE" value="2" />
-    <option name="CONTINUATION_INDENT_SIZE" value="4" />
-    <option name="TAB_SIZE" value="8" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="js">
-    <option name="INDENT_SIZE" value="4" />
-    <option name="CONTINUATION_INDENT_SIZE" value="4" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="jsp">
-    <option name="INDENT_SIZE" value="4" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="php">
-    <option name="INDENT_SIZE" value="4" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="sass">
-    <option name="INDENT_SIZE" value="2" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="xml">
-    <option name="INDENT_SIZE" value="4" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="yml">
-    <option name="INDENT_SIZE" value="2" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <codeStyleSettings language="ECMA Script Level 4">
+  <XML>
+    <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+  </XML>
+  <codeStyleSettings language="CSS">
+    <indentOptions>
+      <option name="INDENT_SIZE" value="4" />
+      <option name="CONTINUATION_INDENT_SIZE" value="8" />
+      <option name="TAB_SIZE" value="4" />
+      <option name="USE_TAB_CHARACTER" value="false" />
+      <option name="SMART_TABS" value="false" />
+      <option name="LABEL_INDENT_SIZE" value="0" />
+      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+      <option name="USE_RELATIVE_INDENTS" value="false" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="HAML">
+    <indentOptions>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="8" />
+      <option name="TAB_SIZE" value="4" />
+      <option name="USE_TAB_CHARACTER" value="false" />
+      <option name="SMART_TABS" value="false" />
+      <option name="LABEL_INDENT_SIZE" value="0" />
+      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+      <option name="USE_RELATIVE_INDENTS" value="false" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="JAVA">
     <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
     <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
     <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
@@ -402,12 +296,27 @@
     <option name="FOR_STATEMENT_WRAP" value="1" />
     <option name="ARRAY_INITIALIZER_WRAP" value="1" />
     <option name="ASSIGNMENT_WRAP" value="5" />
-    <option name="WRAP_COMMENTS" value="true" />
     <option name="IF_BRACE_FORCE" value="3" />
     <option name="DOWHILE_BRACE_FORCE" value="3" />
     <option name="WHILE_BRACE_FORCE" value="3" />
     <option name="FOR_BRACE_FORCE" value="3" />
-    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <indentOptions>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="8" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="JSP">
+    <indentOptions>
+      <option name="INDENT_SIZE" value="4" />
+      <option name="CONTINUATION_INDENT_SIZE" value="8" />
+      <option name="TAB_SIZE" value="4" />
+      <option name="USE_TAB_CHARACTER" value="false" />
+      <option name="SMART_TABS" value="false" />
+      <option name="LABEL_INDENT_SIZE" value="0" />
+      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+      <option name="USE_RELATIVE_INDENTS" value="false" />
+    </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="JavaScript">
     <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
@@ -441,6 +350,16 @@
     <option name="WHILE_BRACE_FORCE" value="3" />
     <option name="FOR_BRACE_FORCE" value="3" />
     <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <indentOptions>
+      <option name="INDENT_SIZE" value="4" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="4" />
+      <option name="USE_TAB_CHARACTER" value="false" />
+      <option name="SMART_TABS" value="false" />
+      <option name="LABEL_INDENT_SIZE" value="0" />
+      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+      <option name="USE_RELATIVE_INDENTS" value="false" />
+    </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="PHP">
     <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
@@ -471,6 +390,27 @@
     <option name="WHILE_BRACE_FORCE" value="3" />
     <option name="FOR_BRACE_FORCE" value="3" />
     <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <indentOptions>
+      <option name="INDENT_SIZE" value="4" />
+      <option name="CONTINUATION_INDENT_SIZE" value="8" />
+      <option name="TAB_SIZE" value="4" />
+      <option name="USE_TAB_CHARACTER" value="false" />
+      <option name="SMART_TABS" value="false" />
+      <option name="LABEL_INDENT_SIZE" value="0" />
+      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+      <option name="USE_RELATIVE_INDENTS" value="false" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="SASS">
+    <indentOptions>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="8" />
+      <option name="TAB_SIZE" value="4" />
+      <option name="USE_TAB_CHARACTER" value="false" />
+      <option name="SMART_TABS" value="false" />
+      <option name="LABEL_INDENT_SIZE" value="0" />
+      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+      <option name="USE_RELATIVE_INDENTS" value="false" />
+    </indentOptions>
   </codeStyleSettings>
 </code_scheme>
-


### PR DESCRIPTION
updated intellij-java-google-style.xml to support version 14, 15 and 2016. Moved static imports from bottom to top as required by the style rules
